### PR TITLE
Lazy generation of sparklines

### DIFF
--- a/melatonin/AudioBlockMatchers.h
+++ b/melatonin/AudioBlockMatchers.h
@@ -175,7 +175,6 @@ namespace melatonin
 
         bool match (AudioBlock<SampleType>& block) const
         {
-            descriptionOfOther = sparkline (other).toStdString();
             for (auto channel = 0; channel < (int) block.getNumChannels(); ++channel)
             {
                 for (auto i = 0; i < (int) block.getNumSamples(); ++i)
@@ -196,6 +195,9 @@ namespace melatonin
 
         std::string describe() const override
         {
+            if (descriptionOfOther.empty())
+                descriptionOfOther = sparkline (other).toStdString();
+
             std::ostringstream ss;
             ss << "is equal to \n"
                << descriptionOfOther << "\n";


### PR DESCRIPTION
Hi again @sudara !

I have a lot of tests and they were taking a very long time. After a little profiling I discovered that sparklines are generated when matching, but they're generally only used if the test fails.
So I made this change and test execution time went from 5 mins (!) to the blink of an eye.