### PR TITLE
Standard juce module format

### DIFF
--- a/melatonin/AudioBlockFFT.h
+++ b/melatonin/AudioBlockFFT.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <juce_dsp/juce_dsp.h>
 
 namespace melatonin
 {

--- a/melatonin/AudioBlockMatchers.h
+++ b/melatonin/AudioBlockMatchers.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_templated.hpp>
 
 // This teaches Catch how to convert an AudioBlock to a string
 // This allows us to print out detail about the AudioBlock on matcher failure

--- a/melatonin/AudioBlockMatchers.h
+++ b/melatonin/AudioBlockMatchers.h
@@ -175,7 +175,6 @@ namespace melatonin
 
         bool match (AudioBlock<SampleType>& block) const
         {
-            descriptionOfOther = sparkline (other).toStdString();
             for (auto channel = 0; channel < (int) block.getNumChannels(); ++channel)
             {
                 for (auto i = 0; i < (int) block.getNumSamples(); ++i)
@@ -196,6 +195,9 @@ namespace melatonin
 
         std::string describe() const override
         {
+            if (descriptionOfOther.empty())
+                descriptionOfOther = sparkline (other).toStdString();
+
             std::ostringstream ss;
             ss << "is equal to \n"
                << descriptionOfOther << "\n";

--- a/melatonin/AudioBlockMatchers.h
+++ b/melatonin/AudioBlockMatchers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "AudioBlockTestHelpers.h"
-#include "melatonin_audio_sparklines/melatonin_audio_sparklines.h"
+#include <modules/melatonin_audio_sparklines/melatonin_audio_sparklines.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_templated.hpp>
 

--- a/melatonin/AudioBlockMatchers.h
+++ b/melatonin/AudioBlockMatchers.h
@@ -1,7 +1,4 @@
 #pragma once
-
-#include "AudioBlockTestHelpers.h"
-#include <modules/melatonin_audio_sparklines/melatonin_audio_sparklines.h>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_templated.hpp>
 

--- a/melatonin/AudioBlockTestHelpers.h
+++ b/melatonin/AudioBlockTestHelpers.h
@@ -155,9 +155,11 @@ namespace melatonin
     template <typename SampleType>
     static inline bool blockIsFilled (const AudioBlock<SampleType>& block)
     {
-        if (numberOfConsecutiveZeros (block) > 0)
+        for (int ch = 0; ch < (int) block.getNumChannels(); ++ch)
         {
-            return false;
+            auto channelBlock = block.getSingleChannelBlock (ch);
+            if (numberOfConsecutiveZeros (channelBlock) > 0)
+                return false;
         }
         return true;
     }

--- a/melatonin/AudioBlockTestHelpers.h
+++ b/melatonin/AudioBlockTestHelpers.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <modules/melatonin_audio_sparklines/melatonin_audio_sparklines.h>
-#include <juce_dsp/juce_dsp.h>
 
 namespace melatonin
 {

--- a/melatonin/AudioBlockTestHelpers.h
+++ b/melatonin/AudioBlockTestHelpers.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "melatonin_audio_sparklines/melatonin_audio_sparklines.h"
+#include <modules/melatonin_audio_sparklines/melatonin_audio_sparklines.h>
 #include <juce_dsp/juce_dsp.h>
 
 namespace melatonin

--- a/melatonin_audio_block_test_helpers.h
+++ b/melatonin_audio_block_test_helpers.h
@@ -11,8 +11,10 @@ BEGIN_JUCE_MODULE_DECLARATION
 
 END_JUCE_MODULE_DECLARATION
 */
-#pragma once
 
+#pragma once
+#include <juce_dsp/juce_dsp.h>
+#include <melatonin_audio_sparklines/melatonin_audio_sparklines.h>
+#include "melatonin/AudioBlockTestHelpers.h"
 #include "melatonin/AudioBlockMatchers.h"
 #include "melatonin/AudioBlockFFT.h"
-#include "melatonin/AudioBlockTestHelpers.h"

--- a/melatonin_audio_block_test_helpers.h
+++ b/melatonin_audio_block_test_helpers.h
@@ -5,7 +5,7 @@ BEGIN_JUCE_MODULE_DECLARATION
  vendor:           Sudara
  version:          1.0.0
  name:             Melatonin AudioBlock Test Helpers
- description:      Nobody Tests Audio Code
+ description:      Nobody Tests Audio Code, but if don't forget to add Catch2 to your build!
  license:          MIT
  dependencies:     juce_dsp, melatonin_audio_sparklines
 
@@ -13,8 +13,12 @@ END_JUCE_MODULE_DECLARATION
 */
 
 #pragma once
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+
 #include <juce_dsp/juce_dsp.h>
 #include <melatonin_audio_sparklines/melatonin_audio_sparklines.h>
+
 #include "melatonin/AudioBlockTestHelpers.h"
 #include "melatonin/AudioBlockMatchers.h"
 #include "melatonin/AudioBlockFFT.h"


### PR DESCRIPTION
I believe this is the 'standard' way of doing juce modules. So basically, no includes in any files, but the module header. I was a bit unsure about the include of Catch, but I guess the cleanest way is to also move that to the module header actually... I'll add a separate commit for that.
This makes it work out of the box for me by doing something like:
`juce_add_module (melatonin_audio_block_test_helpers)`
`target_link_libraries (MyUnitTests melatonin_audio_block_test_helpers)`
