### PR TITLE
Allow compiling without `JUCE_MODAL_LOOPS_ENABLED`

### DIFF
--- a/melatonin_test_helpers.h
+++ b/melatonin_test_helpers.h
@@ -26,4 +26,7 @@ END_JUCE_MODULE_DECLARATION
 #include "melatonin/block_and_buffer_matchers.h"
 #include "melatonin/vector_matchers.h"
 #include "melatonin/mock_playheads.h"
+
+#if JUCE_MODAL_LOOPS_PERMITTED
 #include "melatonin/parameter_test_helpers.h"
+#endif


### PR DESCRIPTION
I'm not using these parameter tests, so I've been having this in my fork for a while, so I don't need to compile with `JUCE_MODAL_LOOPS_ENABLED`.

What do you think of it?